### PR TITLE
Upgrading RHVH hyperconverged host from Admin portal fails for first …

### DIFF
--- a/tasks/upgrade.yml
+++ b/tasks/upgrade.yml
@@ -75,6 +75,16 @@
     - cluster_info.ovirt_clusters[0].gluster_service | bool
     - api_info.ovirt_api.product_info.version.major >= 4 and api_info.ovirt_api.product_info.version.minor >= 4
 
+- name: Stop services
+  service:
+    name: "{{ item }}"
+    state: stopped
+  delegate_to: "{{ host_info.ovirt_hosts[0].address }}"
+  connection: ssh
+  loop:
+  - ovirt-ha-agent.service
+  - ovirt-ha-broker.service
+
 - name: Upgrade host
   ovirt_host:
     auth: "{{ ovirt_auth }}"
@@ -83,6 +93,14 @@
     check_upgrade: "{{ check_upgrade }}"
     reboot_after_upgrade: "{{ reboot_after_upgrade }}"
     timeout: "{{ upgrade_timeout }}"
+
+- name: Start ovirt-ha-agent service
+  service:
+    name: ovirt-ha-agent
+    enabled: yes
+    state: restarted
+  delegate_to: "{{ host_info.ovirt_hosts[0].address }}"
+  connection: ssh
 
 - name: Delay in minutes to wait to finish gluster healing process after successful host upgrade
   pause:


### PR DESCRIPTION
…host

Upgrading RHVH hyperconverged host from Admin portal
fails for first host

Upgrade is failing because ovit-ha-agent is trying to connect vdsm,
and if connection fails, it exits with a non-zero exit code.

after it fails systemd tries to restart the agent, and sincie the
agent wants vdsmd, it also starts vdsmd. This means that if you do:
   systemctl stop vdmsd
and ovirt-ha-agent is in the middle of restart loop,
vdsmd service will start again. This is an impossible situation
so hence just before upgrade stopping the agent and
broker service.

Bug-Url: https://bugzilla.redhat.com/1979539